### PR TITLE
Update install.sh to Resolve the 404 error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 declare current_dir && \
     current_dir="$(dirname "${BASH_SOURCE[0]}")" && \
     cd "${current_dir}" && \
-    source <(curl -s "https://raw.githubusercontent.com/nicholasadamou/utilities/master/utilities.sh")
+    source <(curl -s "https://raw.githubusercontent.com/dotbrains/utilities/refs/heads/master/utilities.sh")
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 


### PR DESCRIPTION
Resolve the 404 error

## Summary by Sourcery

Bug Fixes:
- Fix the 404 error in install.sh by updating the URL to the correct repository.